### PR TITLE
UnicodeDecodeError Fix

### DIFF
--- a/stance/bi_lstm_baseline.py
+++ b/stance/bi_lstm_baseline.py
@@ -31,7 +31,7 @@ def load():
 def get_pretrained_embeddings(path, tokenizer):
     EMBEDDING_DIM = 200
     embeddings_index = {}
-    with open(os.path.join(path, 'glove.6B.200d.txt')) as f:
+    with open(os.path.join(path, 'glove.6B.200d.txt'),encoding='utf-8') as f:
         for line in f:
             values = line.split()
             word = values[0]


### PR DESCRIPTION
Fix for UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6079: character maps to <undefined> in bi_lstm_baseline.py file